### PR TITLE
fixing ${{ }} chars with {% raw %}

### DIFF
--- a/_posts/2021-12-03-consuming-environment-secrets-in-reusable-workflows.markdown
+++ b/_posts/2021-12-03-consuming-environment-secrets-in-reusable-workflows.markdown
@@ -23,11 +23,13 @@ The [documentation ](https://docs.github.com/en/actions/learn-github-actions/reu
 
 If you just want the summary about how to use environment secrets in reusable workflows, then just follow these steps:
 
+{% raw %}
 1. Define secrets in your environment
 1. Make `environment` an input parameter to your reusable workflow
 1. Use `environment: ${{ inputs.environment }}` inside the `job` within the reusable workflow
 1. Declare the `secrets` your reusable workflow requires alongside the `inputs`
 1. When you call the reusable workflow, pass in the secrets
+{% endraw %}
 
 A repo with the workflows is [here](https://github.com/colindembovsky/reusable-workflows-env-secrets). For a longer explanation and some examples, keep on reading!
 
@@ -341,7 +343,9 @@ jobs:
 What does `secrets.PASSWORD` mean here?
 {:.figcaption}
 
+{% raw %}
 If you look closely at the caller workflow, you'll see we're passing `${{ secrets.PASSWORD }}` to the `PASSWORD` secret of the reusable workflow. In this context, the value is actually meaningless, since we're not really "inside" and environment (the workflow doesn't know what the `environment` value means - it's just a string value). What we're really doing is passing the _key_ to the secret that we want the reusable workflow to use.
+{% endraw %}
 
 # Limitations
 


### PR DESCRIPTION
Fixing 2 `${{ }}` in the blog post with `{% raw %}` and `{% endraw %}`

tested locally with `bundle exec jekyll s`

![image](https://user-images.githubusercontent.com/19912012/148956551-3f551961-fdb7-4b82-acbe-40ba65fef4c0.png)

![image](https://user-images.githubusercontent.com/19912012/148956613-3da51dce-d443-4924-b820-c25f3ba6a9f6.png)

